### PR TITLE
go: 1.13 allows binary notation

### DIFF
--- a/sonar-go-plugin/src/test/java/org/sonar/go/converter/GoConverterTest.java
+++ b/sonar-go-plugin/src/test/java/org/sonar/go/converter/GoConverterTest.java
@@ -29,7 +29,7 @@ public class GoConverterTest {
   @Test
   public void test_parse_return() {
     GoConverter converter = new GoConverter(Paths.get("build", "tmp").toFile());
-    Tree tree = converter.parse("package main\nfunc foo() {return 42}");
+    Tree tree = converter.parse("package main\nfunc foo() {return 0b_0010_1010}");
     List<Tree> returnList = tree.descendants().filter(t -> t instanceof ReturnTree).collect(Collectors.toList());
     assertThat(returnList).hasSize(1);
   }

--- a/sonar-go-to-slang/build.gradle
+++ b/sonar-go-to-slang/build.gradle
@@ -17,7 +17,7 @@ sonarqube {
 
 golang {
   packagePath = 'github.com/SonarSource/slang/sonar-go-to-slang'
-  goVersion = '1.13.5'
+  goVersion = '1.14.6'
 }
 
 task generateSource(type: com.github.blindpirate.gogradle.Go) {

--- a/sonar-go-to-slang/build.gradle
+++ b/sonar-go-to-slang/build.gradle
@@ -17,7 +17,7 @@ sonarqube {
 
 golang {
   packagePath = 'github.com/SonarSource/slang/sonar-go-to-slang'
-  goVersion = '1.12.6'
+  goVersion = '1.13.5'
 }
 
 task generateSource(type: com.github.blindpirate.gogradle.Go) {


### PR DESCRIPTION
this should break a test somehow, cf. https://gitlab.com/greut/eclint/-/jobs/387425088, https://sonarcloud.io/project/issues?id=greut_eclint&issues=AW8zHOxJaQJ8ENpsiCgC&open=AW8zHOxJaQJ8ENpsiCgC

https://golang.org/doc/go1.13#language

**Then**

```
> Task :sonar-go-plugin:test                                                                              

org.sonar.go.converter.GoConverterTest > test_parse_return FAILED
    org.sonarsource.slang.api.ParseException: Go parser external process returned non-zero exit value: 2
        at org.sonar.go.converter.GoConverter.executeGoToJsonProcess(GoConverter.java:87)
        at org.sonar.go.converter.GoConverter.parse(GoConverter.java:66)
        at org.sonar.go.converter.GoConverterTest.test_parse_return(GoConverterTest.java:32)
```

**Now**

```
> Task :sonar-go-plugin:test
> Task :sonar-go-plugin:jacocoTestReport
```