### PR TITLE
allow setting vulnerability rule type for checkstyle reports

### DIFF
--- a/checkstyle-import/src/main/java/org/sonarsource/slang/externalreport/CheckstyleFormatImporter.java
+++ b/checkstyle-import/src/main/java/org/sonarsource/slang/externalreport/CheckstyleFormatImporter.java
@@ -169,7 +169,14 @@ public class CheckstyleFormatImporter {
   }
 
   protected RuleType ruleType(String ruleKey, @Nullable String severity) {
-    return "error".equals(severity) ? RuleType.BUG : RuleType.CODE_SMELL;
+    switch(severity) {
+      case "fatal":
+        return RuleType.VULNERABILITY;
+      case "error":
+        return RuleType.BUG;
+      default:
+        return RuleType.CODE_SMELL;
+    }
   }
 
   protected Severity severity(String ruleKey, @Nullable String severity) {

--- a/checkstyle-import/src/main/java/org/sonarsource/slang/externalreport/CheckstyleFormatImporter.java
+++ b/checkstyle-import/src/main/java/org/sonarsource/slang/externalreport/CheckstyleFormatImporter.java
@@ -169,6 +169,10 @@ public class CheckstyleFormatImporter {
   }
 
   protected RuleType ruleType(String ruleKey, @Nullable String severity) {
+    if (severity == null) {
+      return RuleType.CODE_SMELL;
+    }
+
     switch(severity) {
       case "fatal":
         return RuleType.VULNERABILITY;

--- a/checkstyle-import/src/test/java/org/sonarsource/slang/externalreport/CheckstyleFormatImporterTest.java
+++ b/checkstyle-import/src/test/java/org/sonarsource/slang/externalreport/CheckstyleFormatImporterTest.java
@@ -82,9 +82,9 @@ public class CheckstyleFormatImporterTest {
   }
 
   @Test
-  public void import_golandci_lint_issues() throws IOException {
-    List<ExternalIssue> externalIssues = importIssues("golandci-lint-report.xml");
-    assertThat(externalIssues).hasSize(1);
+  public void import_golangci_lint_issues() throws IOException {
+    List<ExternalIssue> externalIssues = importIssues("golangci-lint-report.xml");
+    assertThat(externalIssues).hasSize(2);
 
     ExternalIssue first = externalIssues.get(0);
     assertThat(first.primaryLocation().inputComponent().key()).isEqualTo("externalreport-project:TabCharacter.go");
@@ -93,6 +93,14 @@ public class CheckstyleFormatImporterTest {
     assertThat(first.severity()).isEqualTo(Severity.MAJOR);
     assertThat(first.primaryLocation().message()).isEqualTo("`three` is unused");
     assertThat(first.primaryLocation().textRange().start().line()).isEqualTo(4);
+
+    ExternalIssue second = externalIssues.get(1);
+    assertThat(second.primaryLocation().inputComponent().key()).isEqualTo("externalreport-project:HTTPSClient.go");
+    assertThat(second.ruleKey().rule()).isEqualTo("gosec");
+    assertThat(second.type()).isEqualTo(RuleType.VULNERABILITY);
+    assertThat(second.severity()).isEqualTo(Severity.MAJOR);
+    assertThat(second.primaryLocation().message()).isEqualTo("G402: TLS InsecureSkipVerify set true.");
+    assertThat(second.primaryLocation().textRange().start().line()).isEqualTo(11);
 
     assertThat(logTester.logs(LoggerLevel.ERROR)).isEmpty();
   }

--- a/checkstyle-import/src/test/resources/externalreport/HTTPSClient.go
+++ b/checkstyle-import/src/test/resources/externalreport/HTTPSClient.go
@@ -1,0 +1,16 @@
+// S105
+package samples
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+)
+
+func httpsClient() {
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	_, err := http.Get("https://golang.org/")
+	if err != nil {
+		fmt.Println(err)
+	}
+}

--- a/checkstyle-import/src/test/resources/externalreport/golangci-lint-report.xml
+++ b/checkstyle-import/src/test/resources/externalreport/golangci-lint-report.xml
@@ -3,4 +3,7 @@
   <file name="TabCharacter.go">
     <error column="6" line="4" message="`three` is unused" severity="error" source="deadcode"></error>
   </file>
+  <file name="HTTPSClient.go">
+    <error column="72" line="11" message="G402: TLS InsecureSkipVerify set true." severity="fatal" source="gosec"></error>
+  </file>
 </checkstyle>


### PR DESCRIPTION
Backwards compatible change that allows to set vulnerability rule types for checkstyle reports 

**Unit test results**: https://scans.gradle.com/s/p2ziwr2oykkae

**Integration test results**: https://scans.gradle.com/s/togwoajijp532
(Note I did not touch Ruby and Scala, their failures seem unrelated to my change)