### PR TITLE
Add support for Kotlin trailing commas

### DIFF
--- a/sonar-kotlin-plugin/build.gradle
+++ b/sonar-kotlin-plugin/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 ext {
-    kotlinVersion = '1.3.10'
+    kotlinVersion = '1.3.72'
 }
 
 dependencies {
@@ -65,7 +65,6 @@ shadowJar {
     exclude 'org/jetbrains/kotlin/com/intellij/icons/**'
     exclude 'org/jetbrains/kotlin/com/intellij/lang/jvm/**'
     exclude 'org/jetbrains/kotlin/com/intellij/ui/**'
-    exclude 'org/jetbrains/kotlin/com/intellij/util/io/**'
     exclude 'org/jetbrains/kotlin/com/intellij/util/ui/**'
     exclude 'org/jetbrains/kotlin/com/intellij/util/xmlb/**'
     exclude 'org/jetbrains/kotlin/builtins/**'
@@ -76,7 +75,7 @@ shadowJar {
     exclude 'org/jetbrains/kotlin/types/**'
     exclude 'org/jetbrains/org/**'
     doLast {
-        enforceJarSizeAndCheckContent(new File(libsDir, shadowJar.archiveName), 7_200_000L, 8_200_000L)
+        enforceJarSizeAndCheckContent(new File(libsDir, shadowJar.archiveName), 7_200_000L, 8_300_000L)
     }
 }
 

--- a/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/converter/KotlinConverter.java
+++ b/sonar-kotlin-plugin/src/main/java/org/sonarsource/kotlin/converter/KotlinConverter.java
@@ -22,9 +22,9 @@ package org.sonarsource.kotlin.converter;
 import java.util.Arrays;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.kotlin.cli.common.script.CliScriptDefinitionProvider;
-import org.jetbrains.kotlin.com.intellij.core.CoreASTFactory;
 import org.jetbrains.kotlin.com.intellij.core.CoreFileTypeRegistry;
+import org.jetbrains.kotlin.com.intellij.lang.ASTFactory;
+import org.jetbrains.kotlin.com.intellij.lang.DefaultASTFactoryImpl;
 import org.jetbrains.kotlin.com.intellij.lang.Language;
 import org.jetbrains.kotlin.com.intellij.lang.LanguageASTFactory;
 import org.jetbrains.kotlin.com.intellij.lang.LanguageParserDefinitions;
@@ -56,7 +56,6 @@ import org.jetbrains.kotlin.com.intellij.psi.impl.PsiManagerImpl;
 import org.jetbrains.kotlin.idea.KotlinFileType;
 import org.jetbrains.kotlin.idea.KotlinLanguage;
 import org.jetbrains.kotlin.parsing.KotlinParserDefinition;
-import org.jetbrains.kotlin.script.ScriptDefinitionProvider;
 import org.sonarsource.slang.api.ASTConverter;
 import org.sonarsource.slang.api.ParseException;
 import org.sonarsource.slang.api.TextPointer;
@@ -93,18 +92,16 @@ public class KotlinConverter implements ASTConverter {
     application.registerService(ProgressManager.class, new CoreProgressManager());
     ApplicationManager.setApplication(application, FileTypeRegistry.ourInstanceGetter, disposable);
 
-    Extensions.getArea(null).registerExtensionPoint(MetaLanguage.EP_NAME.getName(), MetaLanguage.class.getName(), ExtensionPoint.Kind.INTERFACE);
-    Extensions.registerAreaClass("IDEA_PROJECT", null);
+    Extensions.getRootArea().registerExtensionPoint(MetaLanguage.EP_NAME.getName(), MetaLanguage.class.getName(), ExtensionPoint.Kind.INTERFACE);
 
     MockProject project = new MockProject(null, disposable);
-    project.registerService(ScriptDefinitionProvider.class, CliScriptDefinitionProvider.class);
 
     LanguageParserDefinitions.INSTANCE.addExplicitExtension(KotlinLanguage.INSTANCE, new KotlinParserDefinition());
-    CoreASTFactory astFactory = new CoreASTFactory();
+    ASTFactory astFactory = new DefaultASTFactoryImpl();
     LanguageASTFactory.INSTANCE.addExplicitExtension(KotlinLanguage.INSTANCE, astFactory);
     LanguageASTFactory.INSTANCE.addExplicitExtension(Language.ANY, astFactory);
 
-    PsiManager psiManager = new PsiManagerImpl(project, fileDocMgr, psiBuilderFactory, null, null, null);
+    PsiManager psiManager = new PsiManagerImpl(project);
     return new PsiFileFactoryImpl(psiManager);
   }
 

--- a/sonar-kotlin-plugin/src/test/resources/ast/trailing-comma.kt
+++ b/sonar-kotlin-plugin/src/test/resources/ast/trailing-comma.kt
@@ -1,0 +1,8 @@
+class Trailing(var a: List<String>,) {
+    fun b(a: String,) {
+        this.a = listOf(
+            a,
+            "",
+        )
+    }
+}

--- a/sonar-kotlin-plugin/src/test/resources/ast/trailing-comma.txt
+++ b/sonar-kotlin-plugin/src/test/resources/ast/trailing-comma.txt
@@ -1,0 +1,62 @@
+AST node class                             | first…last tokens | line:col   
+-------------------------------------------|-------------------|------------
+TopLevelTree {                             | class … }         | 1:1 … 9:1  
+  ClassDeclarationTree {                   | class … }         | 1:1 … 8:2  
+    ?KtClass? {                            | class … }         | 1:1 … 8:2  
+      FunctionDeclarationTree {            | ( … )             | 1:15 … 1:37
+        ParameterTree {                    | var … >           | 1:16 … 1:35
+          IdentifierTree                   | a                 | 1:20 … 1:21
+          ?KtTypeReference? {              | List … >          | 1:23 … 1:35
+            ?KtUserType? {                 | List … >          | 1:23 … 1:35
+              IdentifierTree               | List              | 1:23 … 1:27
+              ?KtTypeArgumentList? {       | < … >             | 1:27 … 1:35
+                ?KtTypeProjection? {       | String            | 1:28 … 1:34
+                  ?KtTypeReference? {      | String            | 1:28 … 1:34
+                    ?KtUserType? {         | String            | 1:28 … 1:34
+                      IdentifierTree       | String            | 1:28 … 1:34
+                    }                      |                   |            
+                  }                        |                   |            
+                }                          |                   |            
+              }                            |                   |            
+            }                              |                   |            
+          }                                |                   |            
+        }                                  |                   |            
+      }                                    |                   |            
+      ?KtClassBody? {                      | { … }             | 1:38 … 8:2 
+        FunctionDeclarationTree {          | fun … }           | 2:5 … 7:6  
+          IdentifierTree                   | b                 | 2:9 … 2:10 
+          ParameterTree {                  | a … String        | 2:11 … 2:20
+            IdentifierTree                 | a                 | 2:11 … 2:12
+            ?KtTypeReference? {            | String            | 2:14 … 2:20
+              ?KtUserType? {               | String            | 2:14 … 2:20
+                IdentifierTree             | String            | 2:14 … 2:20
+              }                            |                   |            
+            }                              |                   |            
+          }                                |                   |            
+          BlockTree {                      | { … }             | 2:23 … 7:6 
+            AssignmentExpressionTree {     | this … )          | 3:9 … 6:10 
+              ?KtDotQualifiedExpression? { | this … a          | 3:9 … 3:15 
+                ?KtThisExpression? {       | this              | 3:9 … 3:13 
+                  IdentifierTree           | this              | 3:9 … 3:13 
+                }                          |                   |            
+                IdentifierTree             | a                 | 3:14 … 3:15
+              }                            |                   |            
+              ?KtCallExpression? {         | listOf … )        | 3:18 … 6:10
+                IdentifierTree             | listOf            | 3:18 … 3:24
+                ?KtValueArgumentList? {    | ( … )             | 3:24 … 6:10
+                  ?KtValueArgument? {      | a                 | 4:13 … 4:14
+                    IdentifierTree         | a                 | 4:13 … 4:14
+                  }                        |                   |            
+                  ?KtValueArgument? {      | " … "             | 5:13 … 5:15
+                    StringLiteralTree      | " … "             | 5:13 … 5:15
+                  }                        |                   |            
+                }                          |                   |            
+              }                            |                   |            
+            }                              |                   |            
+          }                                |                   |            
+        }                                  |                   |            
+      }                                    |                   |            
+      IdentifierTree                       | Trailing          | 1:7 … 1:15 
+    }                                      |                   |            
+  }                                        |                   |            
+}                                          |                   |            


### PR DESCRIPTION
## Overview

* Upgrade embedded Kotlin compiler to version 1.3.72 aka the last one of 1.3.x. Kotlin 1.3.7x is the first one to have [trailing commas support](https://youtrack.jetbrains.com/issue/KT-34743) in the compiler.

* Add a trailing comma test case.

## Details

* Some Kotlin compiler APIs have changed: `CoreASTFactory` removed in favor of `DefaultASTFactoryImpl`, `Extensions.registerAreaClass` removed as no longer required, `PsiManagerImpl` no longer requires anything except `Project`.
* Due to compiler internal changes, `org/jetbrains/kotlin/com/intellij/util/io/**` has to removed from exclusions otherwise integration tests fail with `ClassNotFoundException` for `org.jetbrains.kotlin.com.intellij.util.io.DataOutputStream`.
* Due to compiler size changes shadow jar size limit has to be increased.

## Testing

* All existing unit & integration tests pass when executed locally
* New trailing comma unit test passes

## Open questions

- [ ] It should be possible to upgrade the embedded compiler to 1.4.10 with little to no extra code changes. I imagine that has to be done to completely support Kotin 1.4 ([SONARSLANG-493](https://jira.sonarsource.com/browse/SONARSLANG-493)) however that's not required for trailing commas support.
- [ ] `ScriptDefinitionProvider` and `CliScriptDefinitionProvider` were moved into `org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable` artefact. It should be possible to restore `project.registerService(ScriptDefinitionProvider.class, CliScriptDefinitionProvider.class)` line by adding that dependency but it doesn't look like it's required for any tests to pass.
