### PR TITLE
Fix merge logic for Ruby SimpleCov coverage reports

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/CODEOWNERS @SonarSource/languages-team-jvm
+.github/CODEOWNERS @SonarSource/analysis-jvm-squad

--- a/sonar-ruby-plugin/src/test/java/org/sonarsource/ruby/plugin/SimpleCovSensorTest.java
+++ b/sonar-ruby-plugin/src/test/java/org/sonarsource/ruby/plugin/SimpleCovSensorTest.java
@@ -135,9 +135,9 @@ class SimpleCovSensorTest {
 
     String file1Key = MODULE_KEY + ":file1.rb";
     assertThat(context.lineHits(file1Key, 1)).isZero();
-    assertThat(context.lineHits(file1Key, 2)).isZero();
+    assertThat(context.lineHits(file1Key, 2)).isNull();
     assertThat(context.lineHits(file1Key, 3)).isEqualTo(1);
-    assertThat(context.lineHits(file1Key, 4)).isZero();
+    assertThat(context.lineHits(file1Key, 4)).isNull();
     assertThat(context.lineHits(file1Key, 5)).isNull();
     assertThat(context.lineHits(file1Key, 6)).isEqualTo(1);
     assertThat(context.lineHits(file1Key, 7)).isEqualTo(1);
@@ -155,9 +155,9 @@ class SimpleCovSensorTest {
 
     String file1Key = MODULE_KEY + ":file1.rb";
     assertThat(context.lineHits(file1Key, 1)).isZero();
-    assertThat(context.lineHits(file1Key, 2)).isZero();
+    assertThat(context.lineHits(file1Key, 2)).isNull();
     assertThat(context.lineHits(file1Key, 3)).isEqualTo(1);
-    assertThat(context.lineHits(file1Key, 4)).isZero();
+    assertThat(context.lineHits(file1Key, 4)).isNull();
     assertThat(context.lineHits(file1Key, 5)).isNull();
     assertThat(context.lineHits(file1Key, 6)).isEqualTo(1);
     assertThat(context.lineHits(file1Key, 7)).isEqualTo(1);


### PR DESCRIPTION
SimpleCov reports that don't execute any tests targeting some file include 0 for all lines of that file. If another chunk of tests does cover that file, the "proper" report includes `null`s for non-executable lines.

If then multiple reports are fed to SonarQube, existing merge logic merged `null` and 0 into 0, so non-executable lines of code are reported as non-covered.

SimpleCov includes its own [reports merge logic](https://github.com/simplecov-ruby/simplecov/blob/v0.22.0/lib/simplecov/combine/lines_combiner.rb#L20-L40) which merges null and 0 into null.

This change aligns coverage reports merge logic with SimpleCov's own.